### PR TITLE
Updates to NP Notebook Website - 15 June 2026

### DIFF
--- a/_notebook/Download Notebook eBrochure.md
+++ b/_notebook/Download Notebook eBrochure.md
@@ -5,9 +5,6 @@ variant: tiptap
 description: ""
 ---
 <h4><strong>📢</strong> <strong>Purchase notebook online at the Authorised Notebook Suppliers’ website.</strong></h4>
-<div class="isomer-image-wrapper">
-<img style="width: 100%" height="auto" width="100%" alt="2026 Student Notebook Roadshow Banner" src="/images/2026_notebookbanner_v2.png">
-</div>
 <div class="isomer-card-grid"><a rel="noopener noreferrer nofollow" href="https://www2.np.edu.sg/files/NP_Online_Brochure_09_March_2026_v1.pdf" class="isomer-card"><div class="isomer-card-image"><div class="isomer-image-wrapper"><img style="width: 100%" height="auto" width="100%" alt="Placeholder image" src="/images/Pages/mfp_logo.png"></div></div><div class="isomer-card-body"><div class="isomer-card-title">2026 Models for Purchase</div><div class="isomer-card-description">Please upload a screenshot of your Acceptance Letter, Student Status Letter, Course Registration Submission, or Student ID when placing an online order on the notebook supplier's website. Notebooks will be available for online purchase throughout the year, subject to stock availability.</div><div class="isomer-card-link">Download 2026 Notebook eBrochure</div></div></a>
 </div>
 <hr>

--- a/_notebook/Frequently Asked Questions.md
+++ b/_notebook/Frequently Asked Questions.md
@@ -43,7 +43,7 @@ computer from NP's authorised suppliers as you will enjoy <strong>3 key advantag
 <h4>Is there any financial assistance to help me own a notebook​?</h4>
 <p>Yes. Depending on your household income, you may be eligible for:</p>
 <p>(i) Opportunity Fund Subsidy for notebook</p>
-<p>More information is available on the <a href="https://www.np.edu.sg/admissions-enrolment/guide-for-prospective-students/aid" rel="noopener noreferrer nofollow" target="_blank">Financial Assistance</a> page.</p>
+<p>More information is available on NP's <a href="https://www.np.edu.sg/admissions-enrolment/guide-for-prospective-students/aid" rel="noopener noreferrer nofollow" target="_blank">Financial Aid</a> page.</p>
 <h4>I already have a notebook. Do I need to purchase another one?</h4>
 <p>As long as your notebook complies with your course minimum specifications,
 you need not buy another one. To find out about the minimum specifications

--- a/_notebook/Frequently Asked Questions.md
+++ b/_notebook/Frequently Asked Questions.md
@@ -41,9 +41,8 @@ computer from NP's authorised suppliers as you will enjoy <strong>3 key advantag
 </li>
 </ol>
 <h4>Is there any financial assistance to help me own a notebook​?</h4>
-<p>Yes. Depending on your household income, you may be eligible for either:</p>
-<p>(i) Interest-free Mobile Computing Loan of up to $2,000 for notebook computers</p>
-<p>(ii) Opportunity Fund Subsidy for notebook</p>
+<p>Yes. Depending on your household income, you may be eligible for:</p>
+<p>(i) Opportunity Fund Subsidy for notebook</p>
 <p>More information is available on the <a href="https://www.np.edu.sg/admissions-enrolment/guide-for-prospective-students/aid" rel="noopener noreferrer nofollow" target="_blank">Financial Assistance</a> page.</p>
 <h4>I already have a notebook. Do I need to purchase another one?</h4>
 <p>As long as your notebook complies with your course minimum specifications,

--- a/_notebook/Frequently Asked Questions.md
+++ b/_notebook/Frequently Asked Questions.md
@@ -43,7 +43,8 @@ computer from NP's authorised suppliers as you will enjoy <strong>3 key advantag
 <h4>Is there any financial assistance to help me own a notebook​?</h4>
 <p>Yes. Depending on your household income, you may be eligible for:</p>
 <p>(i) Opportunity Fund Subsidy for notebook</p>
-<p>More information is available on NP's <a href="https://www.np.edu.sg/admissions-enrolment/guide-for-prospective-students/aid" rel="noopener noreferrer nofollow" target="_blank">Financial Aid</a> webpage.</p>
+<p>More information is available on NP's <a href="https://www.np.edu.sg/admissions-enrolment/guide-for-prospective-students/aid" rel="noopener noreferrer nofollow" target="_blank">Financial Aid</a> web
+page.</p>
 <h4>I already have a notebook. Do I need to purchase another one?</h4>
 <p>As long as your notebook complies with your course minimum specifications,
 you need not buy another one. To find out about the minimum specifications

--- a/_notebook/Frequently Asked Questions.md
+++ b/_notebook/Frequently Asked Questions.md
@@ -43,7 +43,7 @@ computer from NP's authorised suppliers as you will enjoy <strong>3 key advantag
 <h4>Is there any financial assistance to help me own a notebook​?</h4>
 <p>Yes. Depending on your household income, you may be eligible for:</p>
 <p>(i) Opportunity Fund Subsidy for notebook</p>
-<p>More information is available on NP's <a href="https://www.np.edu.sg/admissions-enrolment/guide-for-prospective-students/aid" rel="noopener noreferrer nofollow" target="_blank">Financial Aid</a> page.</p>
+<p>More information is available on NP's <a href="https://www.np.edu.sg/admissions-enrolment/guide-for-prospective-students/aid" rel="noopener noreferrer nofollow" target="_blank">Financial Aid</a> webpage.</p>
 <h4>I already have a notebook. Do I need to purchase another one?</h4>
 <p>As long as your notebook complies with your course minimum specifications,
 you need not buy another one. To find out about the minimum specifications

--- a/_notebook/NP Authorised Notebook Suppliers.md
+++ b/_notebook/NP Authorised Notebook Suppliers.md
@@ -5,16 +5,6 @@ variant: tiptap
 description: ""
 ---
 <h4><strong>📢</strong> <strong>Purchase notebook online at the Authorised Notebook Suppliers’ website.</strong></h4>
-<div class="isomer-image-wrapper">
-<img style="width: 100%" height="auto" width="100%" alt="2026 Notebook Banner vClean" src="/images/2026_notebookbanner_vClean.png">
-</div>
-<p>• Priority for notebook purchases will be given to <strong>2026 Freshmen (Full-time &amp; Poly Foundation Programme)</strong>.</p>
-<p>• <strong>IMPORTANT</strong>: Year 2, Year 3 and Full-Time CET students,
-as well as staff, should only purchase from May 2026 onwards*, as freshmen
-are given priority to secure a notebook first. Thank you for your understanding.
-<br>*If you require a notebook urgently for your studies (e.g. a faulty notebook),
-please contact the notebook suppliers directly via email first. Request
-will be subject to review and stock availability.</p>
 <p></p>
 <blockquote>
 <p>Prior to purchasing your notebook, please read "<a href="/notebook/winormac" rel="noopener noreferrer nofollow" target="_blank">Windows or Mac?</a>" and check <a href="/notebook/specs/" rel="noopener noreferrer nofollow" target="_blank">minimum specifications</a> for
@@ -74,7 +64,7 @@ contact details.</p>
 <p>Hotline Hours: 8.30am to 5.30pm (Mon to Fri, excluding Public Holidays)</p>
 </li>
 <li>
-<p>Place Order Online @ <a href="https://e-shop-lenovo.asiapac.com.sg/shop?school=np" rel="noopener noreferrer nofollow" target="_blank">https://e-shop-lenovo.asiapac.com.sg/shop?school=np</a>
+<p>Place Order Online @ <a href="https://e-shop-lenovo.keppeltechsolutions.com/" rel="noopener noreferrer nofollow" target="_blank">https://e-shop-lenovo.keppeltechsolutions.com/</a>
 </p>
 </li>
 </ul>

--- a/_notebook/NP Authorised Notebook Suppliers.md
+++ b/_notebook/NP Authorised Notebook Suppliers.md
@@ -64,7 +64,7 @@ contact details.</p>
 <p>Hotline Hours: 8.30am to 5.30pm (Mon to Fri, excluding Public Holidays)</p>
 </li>
 <li>
-<p>Place Order Online @ <a href="https://e-shop-lenovo.keppeltechsolutions.com/" rel="noopener noreferrer nofollow" target="_blank">https://e-shop-lenovo.keppeltechsolutions.com/</a>
+<p>Place Order Online @ <a href="https://e-shop-lenovo.keppeltechsolutions.com/shop?school=np" rel="noopener noreferrer nofollow" target="_blank">https://e-shop-lenovo.keppeltechsolutions.com/shop?school=np</a>
 </p>
 </li>
 </ul>

--- a/_notebook/NP Authorised Notebook Suppliers.md
+++ b/_notebook/NP Authorised Notebook Suppliers.md
@@ -35,7 +35,7 @@ contact details.</p>
 </p>
 <ul data-tight="true" class="tight">
 <li>
-<p>Email: <a href="mailto:np@keppel.com" rel="noopener noreferrer nofollow" target="_blank">np@keppel.com</a>
+<p>Email: <a href="mailto:DL-np@keppeltechsolutions.com" rel="noopener noreferrer nofollow" target="_blank">DL-np@keppeltechsolutions.com</a>
 </p>
 </li>
 <li>
@@ -45,7 +45,7 @@ contact details.</p>
 <p>Hotline Hours: 8.30am to 5.30pm (Mon to Fri, excluding Public Holidays)</p>
 </li>
 <li>
-<p>Place Order Online @ <a href="https://e-shop-hp.asiapac.com.sg/shop?school=np" rel="noopener noreferrer nofollow" target="_blank">https://e-shop-hp.asiapac.com.sg/shop?school=np</a>
+<p>Place Order Online @ <a href="https://e-shop-hp.keppeltechsolutions.com/shop?school=np" rel="noopener noreferrer nofollow" target="_blank">https://e-shop-hp.keppeltechsolutions.com/shop?school=np</a>
 </p>
 </li>
 </ul>

--- a/_notebook/Notebook Ownership For Mobile eLearning.md
+++ b/_notebook/Notebook Ownership For Mobile eLearning.md
@@ -5,17 +5,6 @@ variant: tiptap
 description: ""
 ---
 <h4><strong>📢</strong> <strong>Purchase notebook online at the Authorised Notebook Suppliers’ website.</strong></h4>
-<div class="isomer-image-wrapper">
-<img style="width: 100%" height="auto" width="100%" alt="2026 Notebook Banner vClean" src="/images/2026_notebookbanner_vClean.png">
-</div>
-<p>• Priority for notebook purchases will be given to <strong>2026 Freshmen (Full-time &amp; Poly Foundation Programme).</strong>
-</p>
-<p>• <strong>IMPORTANT:</strong> Year 2, Year 3 and Full-Time CET students,
-as well as staff, should only purchase from May 2026 onwards*, as freshmen
-are given priority to secure a notebook first. Thank you for your understanding.
-<br>*If you require a notebook urgently for your studies (e.g. a faulty notebook),
-please contact the notebook suppliers directly via email first. Request
-will be subject to review and stock availability.</p>
 <p></p>
 <blockquote>
 <p>You must use your personal notebook computer and other IT device(s) for

--- a/_notebook/Windows or Mac?.md
+++ b/_notebook/Windows or Mac?.md
@@ -5,9 +5,6 @@ variant: tiptap
 description: ""
 ---
 <h4><strong>📢</strong> <strong>Purchase notebook online at the Authorised Notebook Suppliers’ website.</strong></h4>
-<div class="isomer-image-wrapper">
-<img style="width: 100%" height="auto" width="100%" alt="2026 Student Notebook Roadshow Banner" src="/images/2026_notebookbanner_v2.png">
-</div>
 <blockquote>
 <p></p>
 <p>Please check&nbsp;<a href="/notebook/specs/" class="cf0" rel="noopener noreferrer nofollow" target="_blank">minimum specifications</a>&nbsp;for

--- a/index.md
+++ b/index.md
@@ -23,8 +23,6 @@ sections:
         - title: Quick links
           description: For Students
           url: /quick-links/student/
-      button: Download notebook e-brochure
-      url: https://www2.np.edu.sg/files/NP_Online_Brochure_09_March_2026_v1.pdf
   - infopic:
       title: Purchase notebook from our authorised suppliers to get
       id: infopic


### PR DESCRIPTION
-removed download notebook ebrochure button from Digital Services main landing page.
-removed "Priority for Freshman Purchases" graphics from notebook pages.
-updated Keppel Technology email details.
-removed "NP Intrest Free Loan for Notebooks" info.